### PR TITLE
Fix form background reset

### DIFF
--- a/templates/nmap.html
+++ b/templates/nmap.html
@@ -207,8 +207,8 @@
                             var ports = document.getElementById('ports');
                             var tports = document.getElementById('topPorts');
                             // set defult backgrounds
-                            hosts.style = "background-color: fff;";
-                            ports.style = "background-color: fff;";
+                            hosts.style = "background-color: #fff;";
+                            ports.style = "background-color: #fff;";
                             // check if the field "hosts" is non-empty, is mached with
                             // hosts or IPs
                             if (hosts.value == "" || /^[\da-zA-Z,.-\/:]+$/.test(hosts.value) == false) {

--- a/templates/sslyze.html
+++ b/templates/sslyze.html
@@ -121,7 +121,7 @@
                             document.getElementById('valid').disabled=false;
                             var host = document.getElementById('host');
                             // set defult backgrounds
-                            host.style = "background-color: fff;";
+                            host.style = "background-color: #fff;";
                             // check if the field "host" is non-empty, is a url
                             if (host.value == "" || /^(?!(http(s)?):\/\/)[(www\.)?a-zA-Z0-9\.\-]{2,256}\.[a-z]{2,6}/.test(host.value) == false) {
                                 console.log("Invalid host: " + host);

--- a/templates/wapiti.html
+++ b/templates/wapiti.html
@@ -214,7 +214,7 @@
                             document.getElementById('valid').disabled=false;
                             var host = document.getElementById('host');
                             // set defult backgrounds
-                            host.style = "background-color: fff;";
+                            host.style = "background-color: #fff;";
                             // check if the field "host" is non-empty, is a url
                             if (host.value == "" || /(http(s)?):\/\/[(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/.test(host.value) == false) {
                                 console.log("Invalid host: " + host);


### PR DESCRIPTION
## Summary
- ensure Nmap, Wapiti and SSLyze forms restore their background to white

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6852e99df0c48332823ad02fed6f0941